### PR TITLE
[RFR] Remove sp assertions

### DIFF
--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -44,7 +44,7 @@ def test_analyze_known_libraries(analysis_data):
 
     assert 'Report created' in output
 
-    assert_story_points_from_report_file(104)
+    assert_story_points_from_report_file()
 
     with open(report_path + '/api/files.json') as file:
         report_detail = file.read()
@@ -67,7 +67,7 @@ def test_transaction_analysis(analysis_data):
 
     assert 'Report created' in output
 
-    assert_story_points_from_report_file(application_data['story_points'])
+    assert_story_points_from_report_file()
 
     with open(report_path + '/api/transactions.json', 'r') as file:
         json_data = json.load(file)
@@ -179,7 +179,4 @@ def test_export_zip_report(analysis_data):
     with ZipFile(zip_report_path, 'r') as zip_file:
         zip_file.extractall(unzipped_report_path)
 
-    assert_story_points_from_report_file(
-        application_data['story_points'],
-        **{'report_path': unzipped_report_path}
-    )
+    assert_story_points_from_report_file(**{'report_path': unzipped_report_path})

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -21,4 +21,4 @@ def test_standard_analysis(app_name, analysis_data):
 
     assert 'Report created' in output
 
-    assert_story_points_from_report_file(application_data['story_points'])
+    assert_story_points_from_report_file()

--- a/tests/test_excluded_packages.py
+++ b/tests/test_excluded_packages.py
@@ -21,7 +21,7 @@ def test_excluded_packages(analysis_data):
 
     assert 'Report created' in output
 
-    assert_story_points_from_report_file(76)
+    assert_story_points_from_report_file()
 
     with open(report_path + '/api/files.json') as file:
         report_detail = file.read()

--- a/tests/test_invalid_fields.py
+++ b/tests/test_invalid_fields.py
@@ -1,9 +1,6 @@
-import os
 import subprocess
 
 from utils.command import build_command
-from utils.report import assert_story_points_from_report_file
-
 
 def test_invalid_target(analysis_data):
     application_data = analysis_data['jee_example_app']

--- a/utils/report.py
+++ b/utils/report.py
@@ -5,12 +5,11 @@ import os
 from bs4 import BeautifulSoup
 
 
-def assert_story_points_from_report_file(story_points, **kwargs):
+def assert_story_points_from_report_file(**kwargs):
     """
     Asserts that the story points in the report file match the provided value.
 
     Args:
-        story_points (int): The expected story points value to match.
         **kwargs: Optional keyword arguments.
             report_path (str): The path to the report file. If not provided,
                 the function will use the value of the 'REPORT_OUTPUT_PATH' environment variable.
@@ -28,7 +27,7 @@ def assert_story_points_from_report_file(story_points, **kwargs):
     with open(report_path + "/api/applications.json") as file:
         json_data = json.load(file)
 
-    assert json_data[0]['storyPoints'] == story_points
+    assert json_data[0]['storyPoints'] >= 0
 
 
 def assert_valid_csv(csv_file_path, **kwargs):


### PR DESCRIPTION
Removes the SP exact number assertions from all tests and leaves just the existence and numeric type checks.

@sshveta @kpunwatk could you review this PR pleasE?